### PR TITLE
Add SD+ events

### DIFF
--- a/event.go
+++ b/event.go
@@ -4,6 +4,8 @@ package sdk
 type EventName string
 
 const (
+	// [Events Received] (https://docs.elgato.com/sdk/plugins/events-received)
+
 	// DidReceiveSettings Event received after calling the GetSettings API
 	// to retrieve the persistent data stored for the action.
 	DidReceiveSettings EventName = "didReceiveSettings"
@@ -17,6 +19,18 @@ const (
 
 	// KeyUp When the user releases a key, the plugin will receive the keyUp event.
 	KeyUp EventName = "keyUp"
+
+	// When the user touches the display, the plugin will receive the touchTap event (SD+).
+	TouchTap EventName = "touchTap"
+
+	// When the user presses the encoder down, the plugin will receive the dialDown event (SD+).
+	DialDown EventName = "dialDown"
+
+	// When the user releases a pressed encoder, the plugin will receive the dialUp event (SD+).
+	DialUp EventName = "dialUp"
+
+	// When the user rotates the encoder, the plugin will receive the dialRotate event (SD+).
+	DialRotate EventName = "dialRotate"
 
 	// WillAppear When an instance of an action is displayed on the Stream Deck,
 	// for example when the hardware is first plugged in,
@@ -52,6 +66,10 @@ const (
 	// the plugin will be notified and will receive the systemDidWakeUp event.
 	SystemDidWakeUp EventName = "systemDidWakeUp"
 
+	// Occurs when Stream Deck receives a deep-link message intended for the plugin.
+	// The message is re-routed to the plugin, and provided as part of the payload.
+	DidReceiveDeepLink EventName = "didReceiveDeepLink"
+
 	// PropertyInspectorDidAppear Event received when the Property Inspector appears
 	// in the Stream Deck software user interface,
 	// for example when selecting a new instance.
@@ -64,6 +82,8 @@ const (
 
 	// SendToPlugin (from the Property Inspector) Send a payload to the plugin.
 	SendToPlugin EventName = "sendToPlugin"
+
+	// [Events Sent] (https://docs.elgato.com/sdk/plugins/events-sent)
 
 	// SetSettings Save data persistently for the action's instance.
 	SetSettings EventName = "setSettings"
@@ -88,6 +108,19 @@ const (
 
 	// SetImage Dynamically change the image displayed by an instance of an action.
 	SetImage EventName = "setImage"
+
+	// Dynamically change properties of items on the Stream Deck + touch display.
+	SetFeedback EventName = "setFeedback"
+
+	// Dynamically change the current layout for the Stream Deck + touch display.
+	SetFeedbackLayout EventName = "setFeedbackLayout"
+
+	// Sets the trigger descriptions associated with an encoder (touch display + dial) action instance.
+	// All descriptions are optional; when one or more descriptions are defined all descriptions are updated,
+	// with undefined values having their description hidden in Stream Deck.
+	// To reset the descriptions to the default values defined within the manifest,
+	// an empty payload can be sent as part of the event.
+	SetTriggerDescription EventName = "setTriggerDescription"
 
 	// ShowAlert Temporarily show an alert icon on the image displayed by an instance of an action.
 	ShowAlert EventName = "showAlert"
@@ -164,11 +197,32 @@ type ReceivedEventPayload struct {
 	// This json object contains data that you can set and is stored persistently.
 	Settings map[string]interface{} `json:"settings"`
 
+	// Contain value: 'Encoder'.
+	// Used on events: touchTap, dialDown, dialUp, dialRotate
+	Controller string `json:"controller"`
+
 	// The coordinates of the action triggered.
 	Coordinates struct {
 		Column uint8 `json:"column"`
 		Row    uint8 `json:"row"`
 	} `json:"coordinates"`
+
+	// The array which holds (x, y) coordinates as a position of tap inside of LCD slot associated with action.
+	// Used on events: touchTap
+	TapPos [2]int `json:"tapPos"`
+
+	// Boolean which is true when long tap happened.
+	// Used on events: touchTap
+	Hold bool `json:"hold"`
+
+	// The integer which holds the number of "ticks" on encoder rotation.
+	// Positive values are for clockwise rotation, negative values are for counterclockwise rotation, zero value is never happen
+	// Used on events: dialRotate
+	Ticks int `json:"ticks"`
+
+	// Boolean which is true on rotation when encoder pressed
+	// Used on events: dialRotate
+	Pressed bool `json:"pressed"`
 
 	// This is a parameter that is only set when the action has multiple states defined in its manifest.json.
 	// The 0-based value contains the current state of the action.
@@ -182,10 +236,10 @@ type ReceivedEventPayload struct {
 	// Only the value 0 and 1 are valid.
 	UserDesiredState uint8 `json:"userDesiredState"`
 
-	// The new title. Used on events titleParametersDidChange
+	// The new title. Used on events: titleParametersDidChange
 	Title string `json:"title"`
 
-	// A json object describing the new title parameters. Used on events titleParametersDidChange
+	// A json object describing the new title parameters. Used on events: titleParametersDidChange
 	TitleParameters struct {
 		FontFamily     string `json:"fontFamily"`
 		FontSize       int    `json:"fontSize"`
@@ -197,7 +251,7 @@ type ReceivedEventPayload struct {
 	} `json:"titleParameters"`
 
 	// The identifier of the application that has been launched.
-	// Used on events applicationDidLaunch, applicationDidTerminate
+	// Used on events: applicationDidLaunch, applicationDidTerminate
 	Application string `json:"application"`
 }
 
@@ -215,10 +269,14 @@ const (
 	Software
 )
 
+type Payload interface {
+	// Define common methods for all payloads here, if any.
+}
+
 // SendEvent describes a event to send to StreamDeck SDK.
 type SendEvent struct {
 	// The action unique identifier.
-	// Used on events sendToPropertyInspector, sendToPlugin
+	// Used on events: sendToPropertyInspector, sendToPlugin
 	Action string `json:"action,omitempty"`
 
 	// Used to register this plugin
@@ -234,40 +292,69 @@ type SendEvent struct {
 	Device string `json:"device,omitempty"`
 
 	// A json object
-	Payload *SendEventPayload `json:"payload,omitempty"`
+	Payload Payload `json:"payload,omitempty"`
 }
 
 // SendEventPayload describes a payload to send to StreamDeck SDK.
 type SendEventPayload struct {
 	// A URL to open in the default browser.
-	// Used on events openUrl
+	// Used on events: openUrl
 	URL string `json:"url,omitempty"`
 
 	// A string to write to the logs file.
-	// Used on events logMessage
+	// Used on events: logMessage
 	Message string `json:"message,omitempty"`
 
 	// The title to display. If there is no title parameter, the title is reset to the title set by the user.
-	// Used on events setTitle
+	// Used on events: setTitle
 	Title string `json:"title,omitempty"`
 
 	// Specify where you want to display the title.
-	// Used on events setTitle, setImage
+	// Used on events: setTitle, setImage
 	Target Target `json:"target,omitempty"`
 
 	// A 0-based integer value representing the state of an action with multiple states.
 	// This is an optional parameter.
 	// If not specified, the title is set to all states.
-	// Used on events setTitle, setImage, setState
+	// Used on events: setTitle, setImage, setState
 	State uint8 `json:"state,omitempty"`
 
 	// The image to display encoded in base64 with the image format declared in the mime type (PNG, JPEG, BMP, ...).
 	// svg is also supported.
 	// If no image is passed, the image is reset to the default image from the manifest.
-	// Used on events setImage
+	// Used on events: setImage
 	Image string `json:"image,omitempty"`
 
 	// The name of the profile to switch to. The name should be identical to the name provided in the manifest.json file.
-	// Used on events switchToProfile
+	// Used on events: switchToProfile
 	Profile string `json:"profile,omitempty"`
+}
+
+// SendEventSetTriggerDescriptionPayload describes a payload for setTriggerDescription event to send to StreamDeck SDK.
+type SendEventSetTriggerDescriptionPayload struct {
+	// Optional value that describes the long-touch interaction with the touch display.
+	// When undefined the description will be hidden.
+	LongTouch string `json:"longTouch,omitempty"`
+
+	// Optional value that describes the push interaction with the dial.
+	// When undefined the description will be hidden.
+	Push string `json:"push,omitempty"`
+
+	// Optional value that describes the rotate interaction with the dial.
+	// When undefined the description will be hidden.
+	Rotate string `json:"rotate,omitempty"`
+
+	// Optional value that describes the touch interaction with the touch display.
+	// When undefined the description will be hidden.
+	Touch string `json:"touch,omitempty"`
+}
+
+// SendEventSetFeedbackPayload describes a payload for setFeedback event to send to StreamDeck SDK.
+type SendEventSetFeedbackPayload map[string]interface{}
+
+// SendEventSetFeedbackLayoutPayload describes a payload for setFeedbackLayout event to send to StreamDeck SDK.
+type SendEventSetFeedbackLayoutPayload struct {
+	// The layout to display on the Stream Deck + touch display.
+	// See [Layouts](https://docs.elgato.com/sdk/plugins/layouts-sd+)
+	Layout string `json:"layout"`
 }

--- a/event.go
+++ b/event.go
@@ -166,6 +166,33 @@ const (
 	KeyPad  Controller = "KeyPad"
 )
 
+// Layouts used with StreamDeck.
+const (
+	// IconLayout is a layout that displays an icon on the Stream Deck + touch display.
+	// See [Icon Layout](https://docs.elgato.com/sdk/plugins/layouts-sd+#icon-layout-usdx1)
+	IconLayout = "$X1"
+
+	// CanvasLayout is a layout that displays a canvas on the Stream Deck + touch display.
+	// See [Canvas Layout](https://docs.elgato.com/sdk/plugins/layouts-sd+#canvas-layout-usda0)
+	CanvasLayout = "$A0"
+
+	// ValueLayout is a layout that displays a value on the Stream Deck + touch display.
+	// See [Value Layout](https://docs.elgato.com/sdk/plugins/layouts-sd+#value-layout-usda1)
+	ValueLayout = "$A0"
+
+	// IndicatorLayout is a layout that displays an indicator on the Stream Deck + touch display.
+	// See [Indicator Layout](https://docs.elgato.com/sdk/plugins/layouts-sd+#indicator-layout-usdb1)
+	IndicatorLayout = "$B1"
+
+	// GradientIndicatorLayout is a layout that displays a gradient indicator on the Stream Deck + touch display.
+	// See [Gradient Indicator Layout](https://docs.elgato.com/sdk/plugins/layouts-sd+#gradient-indicator-layout-usdb2)
+	GradientIndicatorLayout = "$B2"
+
+	// DoubleIndicatorLayout is a layout that displays a double indicator on the Stream Deck + touch display.
+	// See [Double Indicator Layout](https://docs.elgato.com/sdk/plugins/layouts-sd+#double-indicator-layout-usdc1)
+	DoubleIndicatorLayout = "$C1"
+)
+
 // ReceivedEvent describes a received event from StreamDeck SDK.
 type ReceivedEvent struct {
 	// The action's unique identifier. If your plugin supports multiple actions,

--- a/event.go
+++ b/event.go
@@ -304,10 +304,6 @@ const (
 	Software
 )
 
-type Payload interface {
-	// Define common methods for all payloads here, if any.
-}
-
 // SendEvent describes a event to send to StreamDeck SDK.
 type SendEvent struct {
 	// The action unique identifier.
@@ -327,7 +323,7 @@ type SendEvent struct {
 	Device string `json:"device,omitempty"`
 
 	// A json object
-	Payload Payload `json:"payload,omitempty"`
+	Payload interface{} `json:"payload,omitempty"`
 }
 
 // SendEventPayload describes a payload to send to StreamDeck SDK.

--- a/event.go
+++ b/event.go
@@ -158,6 +158,14 @@ const (
 	KESDSDKDeviceTypeCorsairGKeys
 )
 
+// Controller used with StreamDeck.
+type Controller string
+
+const (
+	Encoder Controller = "Encoder"
+	KeyPad  Controller = "KeyPad"
+)
+
 // ReceivedEvent describes a received event from StreamDeck SDK.
 type ReceivedEvent struct {
 	// The action's unique identifier. If your plugin supports multiple actions,
@@ -197,9 +205,9 @@ type ReceivedEventPayload struct {
 	// This json object contains data that you can set and is stored persistently.
 	Settings map[string]interface{} `json:"settings"`
 
-	// Contain value: 'Encoder'.
+	// Contain value: 'Encoder' or 'KeyPad'.
 	// Used on events: touchTap, dialDown, dialUp, dialRotate
-	Controller string `json:"controller"`
+	Controller Controller `json:"controller"`
 
 	// The coordinates of the action triggered.
 	Coordinates struct {

--- a/events.go
+++ b/events.go
@@ -45,3 +45,21 @@ func (s *StreamDeck) SetImage(context string, image string) {
 		Payload: &SendEventPayload{Image: image},
 	}
 }
+
+// SetTriggerDescription change the trigger description of an action with given context.
+func (s *StreamDeck) SetTriggerDescription(context string, payload *SendEventSetTriggerDescriptionPayload) {
+	s.writeCh <- &SendEvent{
+		Event:   SetTriggerDescription,
+		Context: context,
+		Payload: payload,
+	}
+}
+
+// SetFeedback change the feedback of an action with given context.
+func (s *StreamDeck) SetFeedback(context string, payload *SendEventSetFeedbackPayload) {
+	s.writeCh <- &SendEvent{
+		Event:   SetFeedback,
+		Context: context,
+		Payload: payload,
+	}
+}

--- a/events.go
+++ b/events.go
@@ -63,3 +63,12 @@ func (s *StreamDeck) SetFeedback(context string, payload *SendEventSetFeedbackPa
 		Payload: payload,
 	}
 }
+
+// SetFeedbackLayout change the feedback layout of an action with given context.
+func (s *StreamDeck) SetFeedbackLayout(context string, layout string) {
+	s.writeCh <- &SendEvent{
+		Event:   SetFeedbackLayout,
+		Context: context,
+		Payload: &SendEventSetFeedbackLayoutPayload{Layout: layout},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,4 @@ module github.com/SkYNewZ/streamdeck-sdk
 
 go 1.17
 
-require (
-	github.com/gorilla/websocket v1.4.2
-	github.com/sirupsen/logrus v1.8.1
-)
-
-require golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+require github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,2 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
-github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=


### PR DESCRIPTION
Add events for SD+.

New Events:
- `touchTap` https://docs.elgato.com/sdk/plugins/events-received#touchtap-sd
- `dialDown` https://docs.elgato.com/sdk/plugins/events-received#dialdown-sd
- `dialUp` https://docs.elgato.com/sdk/plugins/events-received#dialup-sd
- `dialRotate` https://docs.elgato.com/sdk/plugins/events-received#dialrotate-sd
- `setFeedback` https://docs.elgato.com/sdk/plugins/events-sent#setfeedback-sd
- `setFeedbackLayout` https://docs.elgato.com/sdk/plugins/events-sent#setfeedbacklayout-sd
- `setTriggerDescription` https://docs.elgato.com/sdk/plugins/events-sent#settriggerdescription-sd